### PR TITLE
Add wrapper around make

### DIFF
--- a/src/class_resolver/api.py
+++ b/src/class_resolver/api.py
@@ -112,6 +112,12 @@ class Resolver(Generic[X]):
         # An instance was passed, and it will go through without modification.
         return query
 
+    def make_from_kwargs(self, kwargs: Mapping[str, Any], key: str, kwargs_suffix: str = "kwargs", **o_kwargs) -> X:
+        """Instantiate a class, by looking up query/pos_kwargs from a dictionary."""
+        query = kwargs.get(key, None)
+        pos_kwargs = kwargs.get(f"{key}_{kwargs_suffix}", {})
+        return self.make(query=query, pos_kwargs=pos_kwargs, **o_kwargs)
+
     def get_option(self, *flags: str, default: Optional[str] = None, **kwargs):
         """Get a click option for this resolver."""
         if default is None:

--- a/src/class_resolver/api.py
+++ b/src/class_resolver/api.py
@@ -128,6 +128,7 @@ class Resolver(Generic[X]):
             and ``kwargs_suffix='kwargs'`` (the default value), then the kwargs from :func:`make` are looked up
             via ``data['model_kwargs']``.
         :param o_kwargs: Additional kwargs to be passed to :func:`make`
+        :returns: An instance of the X datatype parametrized by this resolver
         """
         query = data.get(key, None)
         pos_kwargs = data.get(f"{key}_{kwargs_suffix}", {})

--- a/src/class_resolver/api.py
+++ b/src/class_resolver/api.py
@@ -112,7 +112,14 @@ class Resolver(Generic[X]):
         # An instance was passed, and it will go through without modification.
         return query
 
-    def make_from_kwargs(self, kwargs: Mapping[str, Any], key: str, kwargs_suffix: str = "kwargs", **o_kwargs) -> X:
+    def make_from_kwargs(
+        self,
+        key: str,
+        kwargs: Mapping[str, Any],
+        *,
+        kwargs_suffix: str = "kwargs",
+        **o_kwargs,
+    ) -> X:
         """Instantiate a class, by looking up query/pos_kwargs from a dictionary."""
         query = kwargs.get(key, None)
         pos_kwargs = kwargs.get(f"{key}_{kwargs_suffix}", {})

--- a/src/class_resolver/api.py
+++ b/src/class_resolver/api.py
@@ -114,15 +114,23 @@ class Resolver(Generic[X]):
 
     def make_from_kwargs(
         self,
+        data: Mapping[str, Any],
         key: str,
-        kwargs: Mapping[str, Any],
         *,
         kwargs_suffix: str = "kwargs",
         **o_kwargs,
     ) -> X:
-        """Instantiate a class, by looking up query/pos_kwargs from a dictionary."""
-        query = kwargs.get(key, None)
-        pos_kwargs = kwargs.get(f"{key}_{kwargs_suffix}", {})
+        """Instantiate a class, by looking up query/pos_kwargs from a dictionary.
+
+        :param data: A dictionary that contains entry ``key`` and entry ``{key}_{kwargs_suffix}``.
+        :param key: The key in the dictionary whose value will be put in the ``query`` argument of :func:`make`.
+        :param kwargs_suffix: The suffix after ``key`` to look up the data. For example, if ``key='model'``
+            and ``kwargs_suffix='kwargs'`` (the default value), then the kwargs from :func:`make` are looked up
+            via ``data['model_kwargs']``.
+        :param o_kwargs: Additional kwargs to be passed to :func:`make`
+        """
+        query = data.get(key, None)
+        pos_kwargs = data.get(f"{key}_{kwargs_suffix}", {})
         return self.make(query=query, pos_kwargs=pos_kwargs, **o_kwargs)
 
     def get_option(self, *flags: str, default: Optional[str] = None, **kwargs):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -56,6 +56,17 @@ class TestResolver(unittest.TestCase):
         # Test instantiating with kwargs
         self.assertEqual(A(name=name), self.resolver.make('a', name=name))
 
+    def test_make_from_kwargs(self):
+        """Test making classes from kwargs."""
+        name = "charlie"
+        self.assertEqual(A(name=name), self.resolver.make_from_kwargs(kwargs=dict(
+            ignored_entry=...,
+            magic="a",
+            magic_kwargs=dict(
+                name=name,
+            ),
+        ), key="magic"))
+
     def test_passthrough(self):
         """Test instances are passed through unmodified."""
         a = A(name='charlie')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,13 +59,16 @@ class TestResolver(unittest.TestCase):
     def test_make_from_kwargs(self):
         """Test making classes from kwargs."""
         name = "charlie"
-        self.assertEqual(A(name=name), self.resolver.make_from_kwargs(kwargs=dict(
-            ignored_entry=...,
-            magic="a",
-            magic_kwargs=dict(
-                name=name,
+        self.assertEqual(A(name=name), self.resolver.make_from_kwargs(
+            key="magic",
+            kwargs=dict(
+                ignored_entry=...,
+                magic="a",
+                magic_kwargs=dict(
+                    name=name,
+                ),
             ),
-        ), key="magic"))
+        ))
 
     def test_passthrough(self):
         """Test instances are passed through unmodified."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,7 +61,7 @@ class TestResolver(unittest.TestCase):
         name = "charlie"
         self.assertEqual(A(name=name), self.resolver.make_from_kwargs(
             key="magic",
-            kwargs=dict(
+            data=dict(
                 ignored_entry=...,
                 magic="a",
                 magic_kwargs=dict(


### PR DESCRIPTION
Addresses reading the
```
key: X
key_kwargs: Optional[Mapping[str, Any]]
```
pattern from a method's parameters