### PR TITLE
Optionally do not resolve class in click option

### DIFF
--- a/src/class_resolver/api.py
+++ b/src/class_resolver/api.py
@@ -157,7 +157,7 @@ class Resolver(Generic[X]):
         pos_kwargs = data.get(f"{key}_{kwargs_suffix}", {})
         return self.make(query=query, pos_kwargs=pos_kwargs, **o_kwargs)
 
-    def get_option(self, *flags: str, default: Optional[str] = None, **kwargs):
+    def get_option(self, *flags: str, default: Optional[str] = None, as_string: bool = False, **kwargs):
         """Get a click option for this resolver."""
         if default is None:
             if self.default is None:
@@ -171,7 +171,7 @@ class Resolver(Generic[X]):
             type=click.Choice(list(self.lookup_dict)),
             default=default,
             show_default=True,
-            callback=_make_callback(self.lookup),
+            callback=None if as_string else _make_callback(self.lookup),
             **kwargs,
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -115,6 +115,9 @@ class TestResolver(unittest.TestCase):
             self.assertIsInstance(opt, type)
             click.echo(opt.__name__, nl=False)
 
+        self._test_cli(cli)
+
+    def _test_cli(self, cli):
         runner = CliRunner()
 
         # Test default
@@ -128,3 +131,15 @@ class TestResolver(unittest.TestCase):
         # Test normalizing name
         result: Result = runner.invoke(cli, ['--opt', 'a'])
         self.assertEqual(A.__name__, result.output)
+
+    def test_click_option_str(self):
+        """Test the click option."""
+
+        @click.command()
+        @self.resolver.get_option('--opt', default='a', as_string=True)
+        def cli(opt):
+            """Run the test CLI."""
+            self.assertIsInstance(opt, str)
+            click.echo(self.resolver.lookup(opt).__name__, nl=False)
+
+        self._test_cli(cli)


### PR DESCRIPTION
This is useful, e.g., for serialization.

It occurred when using

```
import wandb
wandb.config.update(click.get_current_context().params)
```

to log the CLI parameters to [wandb](https://wandb.ai/).