### PR TITLE
Handle default value of click option for multiple=True

### DIFF
--- a/src/class_resolver/api.py
+++ b/src/class_resolver/api.py
@@ -337,7 +337,7 @@ class Resolver(Generic[X]):
         return click.option(
             *flags,
             type=click.Choice(list(self.lookup_dict), case_sensitive=False),
-            default=default,
+            default=[default] if kwargs.get("multiple") else default,
             show_default=True,
             callback=None if as_string else _make_callback(self.lookup),
             **kwargs,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,7 @@
 
 import itertools
 import unittest
-from typing import ClassVar, Collection, Optional
+from typing import ClassVar, Collection, Optional, Sequence
 
 import click
 from click.testing import CliRunner, Result
@@ -204,6 +204,20 @@ class TestResolver(unittest.TestCase):
             """Run the test CLI."""
             self.assertIsInstance(opt, str)
             click.echo(self.resolver.lookup(opt).__name__, nl=False)
+
+        self._test_cli(cli)
+
+    def test_click_option_multiple(self):
+        """Test the click option with multiple arguments."""
+
+        @click.command()
+        @self.resolver.get_option("--opt", default="a", as_string=True, multiple=True)
+        def cli(opt):
+            """Run the test CLI."""
+            self.assertIsInstance(opt, Sequence)
+            for opt_ in opt:
+                self.assertIsInstance(opt_, str)
+                click.echo(self.resolver.lookup(opt_).__name__, nl=False)
 
         self._test_cli(cli)
 


### PR DESCRIPTION
When using `multiple=True`, the default of a click option needs to be a list (or tuple), cf. https://click.palletsprojects.com/en/7.x/options/#multiple-options

This PR adds properly handling this case to `Resolver.get_option`.