### PR TITLE
Add `ReduceLROnPlateau` to `torch.lr_scheduler_resolver`

### DIFF
--- a/src/class_resolver/contrib/torch.py
+++ b/src/class_resolver/contrib/torch.py
@@ -5,7 +5,7 @@
 from torch import nn
 from torch.nn import init
 from torch.nn.modules import activation
-from torch.optim import Adam, Optimizer
+from torch.optim import Adam, Optimizer, ReduceLROnPlateau
 from torch.optim.lr_scheduler import ExponentialLR, _LRScheduler
 
 from ..api import ClassResolver
@@ -70,3 +70,4 @@ lr_scheduler_resolver = ClassResolver.from_subclasses(
     default=ExponentialLR,
     suffix="LR",
 )
+lr_scheduler_resolver.register(ReduceLROnPlateau, raise_on_conflict=False)

--- a/src/class_resolver/contrib/torch.py
+++ b/src/class_resolver/contrib/torch.py
@@ -5,8 +5,8 @@
 from torch import nn
 from torch.nn import init
 from torch.nn.modules import activation
-from torch.optim import Adam, Optimizer, ReduceLROnPlateau
-from torch.optim.lr_scheduler import ExponentialLR, _LRScheduler
+from torch.optim import Adam, Optimizer
+from torch.optim.lr_scheduler import ExponentialLR, ReduceLROnPlateau, _LRScheduler
 
 from ..api import ClassResolver
 from ..func import FunctionResolver

--- a/src/class_resolver/contrib/torch.py
+++ b/src/class_resolver/contrib/torch.py
@@ -70,4 +70,4 @@ lr_scheduler_resolver = ClassResolver.from_subclasses(
     default=ExponentialLR,
     suffix="LR",
 )
-lr_scheduler_resolver.register(ReduceLROnPlateau, raise_on_conflict=False)
+lr_scheduler_resolver.register(ReduceLROnPlateau)

--- a/tests/test_contrib/test_torch.py
+++ b/tests/test_contrib/test_torch.py
@@ -58,12 +58,13 @@ class TestTorch(unittest.TestCase):
 
     def test_lr(self):
         """Tests for the learning rate scheduler."""
-        from torch.optim.lr_scheduler import ExponentialLR, LambdaLR
+        from torch.optim.lr_scheduler import ExponentialLR, LambdaLR, ReduceLrOnPlateau
 
         from class_resolver.contrib.torch import lr_scheduler_resolver
 
         self.assertEqual(LambdaLR, lr_scheduler_resolver.lookup("lambda"))
         self.assertEqual(LambdaLR, lr_scheduler_resolver.lookup("lambdalr"))
+        self.assertEqual(ReduceLrOnPlateau, lr_scheduler_resolver.lookup("reducelronplateau"))
         self.assertEqual(ExponentialLR, lr_scheduler_resolver.lookup("exponential"))
         self.assertEqual(ExponentialLR, lr_scheduler_resolver.lookup("exponentiallr"))
         self.assertEqual(ExponentialLR, lr_scheduler_resolver.lookup(None))

--- a/tests/test_contrib/test_torch.py
+++ b/tests/test_contrib/test_torch.py
@@ -58,13 +58,13 @@ class TestTorch(unittest.TestCase):
 
     def test_lr(self):
         """Tests for the learning rate scheduler."""
-        from torch.optim.lr_scheduler import ExponentialLR, LambdaLR, ReduceLrOnPlateau
+        from torch.optim.lr_scheduler import ExponentialLR, LambdaLR, ReduceLROnPlateau
 
         from class_resolver.contrib.torch import lr_scheduler_resolver
 
         self.assertEqual(LambdaLR, lr_scheduler_resolver.lookup("lambda"))
         self.assertEqual(LambdaLR, lr_scheduler_resolver.lookup("lambdalr"))
-        self.assertEqual(ReduceLrOnPlateau, lr_scheduler_resolver.lookup("reducelronplateau"))
+        self.assertEqual(ReduceLROnPlateau, lr_scheduler_resolver.lookup("reducelronplateau"))
         self.assertEqual(ExponentialLR, lr_scheduler_resolver.lookup("exponential"))
         self.assertEqual(ExponentialLR, lr_scheduler_resolver.lookup("exponentiallr"))
         self.assertEqual(ExponentialLR, lr_scheduler_resolver.lookup(None))


### PR DESCRIPTION
The `ClassResolver` is unable to add `torch.optim.lr_scheduler.ReduceLROnPlateau` to the resolver because it inherits from `object` and not `torch.optim.lr_scheduler._LRScheduler`. This PR fixes this by explicitly registering it.