### PR TITLE
Add kwarg checker

### DIFF
--- a/src/class_resolver/metaresolver.py
+++ b/src/class_resolver/metaresolver.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, Mapping, Type, TypeVar
+import inspect
+from typing import Any, Iterable, Mapping, Optional, Tuple, Type, TypeVar
 
 from .api import ClassResolver
 from .utils import Hint, OptionalKwargs
@@ -19,26 +20,48 @@ class Metaresolver:
 
     def __init__(self, resolvers: Iterable[ClassResolver]):
         self.resolvers: Mapping[Type, ClassResolver] = {
-            resolver.base: resolver
-            for resolver in resolvers
+            resolver.base: resolver for resolver in resolvers
         }
-        self.names = {
-            resolver.normalize_cls(cls): resolver
-            for cls, resolver in self.resolvers.items()
-        }
+        self.names = {resolver.suffix: resolver for cls, resolver in self.resolvers.items()}
 
     def check_kwargs(self, base: Type[X], query: Hint[X], kwargs: OptionalKwargs) -> bool:
         main = self.resolvers[base]
         signature = main.signature(query)
         parameters = signature.parameters
-
-        for name, parameter in parameters.items():
+        for key, parameter, related_key, related_parameter in _iter_params(parameters):
             annotation = parameter.annotation
-
-            next_resolver = self.names.get(name)
+            next_resolver = self.names.get(key)
             if next_resolver is None:
-                raise NotImplementedError
+                if key not in kwargs:
+                    if parameter.default is parameter.empty:
+                        raise ValueError(f"{key} without default not given")
+                else:
+                    if not isinstance(kwargs[key], parameter.annotation):
+                        raise TypeError
             elif not is_hint(annotation, next_resolver.base):
-                raise TypeError
+                raise TypeError(
+                    f"{key} has bad annotation {annotation} wrt resolver {next_resolver}"
+                )
+            elif not self.check_kwargs(
+                next_resolver.base,
+                next_resolver.lookup(kwargs[key]),
+                kwargs[related_key],
+            ):
+                return False
             else:
-                raise NotImplementedError
+                continue
+
+
+def _iter_params(
+    parameters,
+) -> Iterable[Tuple[str, inspect.Parameter, str, Optional[inspect.Parameter]]]:
+    kwarg_map = {}
+    for key in parameters.items():
+        related_key = f"{key}_kwargs"
+        if related_key in parameters:
+            kwarg_map[key] = related_key
+    for key in parameters:
+        related_key = f"{key}_kwargs"
+        if key in kwarg_map:
+            continue
+        yield key, parameters[key], related_key, parameters.get(related_key)

--- a/src/class_resolver/metaresolver.py
+++ b/src/class_resolver/metaresolver.py
@@ -1,0 +1,44 @@
+from typing import Any, Iterable, Mapping, Type, TypeVar
+
+from .api import ClassResolver
+from .utils import Hint, OptionalKwargs
+
+X = TypeVar("X")
+
+__all__ = [
+    "Metaresolver",
+]
+
+
+def is_hint(hint: Any, cls: Type[X]) -> bool:
+    return hint == Hint[cls]
+
+
+class Metaresolver:
+    """A resolver of resolvers."""
+
+    def __init__(self, resolvers: Iterable[ClassResolver]):
+        self.resolvers: Mapping[Type, ClassResolver] = {
+            resolver.base: resolver
+            for resolver in resolvers
+        }
+        self.names = {
+            resolver.normalize_cls(cls): resolver
+            for cls, resolver in self.resolvers.items()
+        }
+
+    def check_kwargs(self, base: Type[X], query: Hint[X], kwargs: OptionalKwargs) -> bool:
+        main = self.resolvers[base]
+        signature = main.signature(query)
+        parameters = signature.parameters
+
+        for name, parameter in parameters.items():
+            annotation = parameter.annotation
+
+            next_resolver = self.names.get(name)
+            if next_resolver is None:
+                raise NotImplementedError
+            elif not is_hint(annotation, next_resolver.base):
+                raise TypeError
+            else:
+                raise NotImplementedError

--- a/tests/test_metaresolver.py
+++ b/tests/test_metaresolver.py
@@ -1,0 +1,119 @@
+import unittest
+from typing import Optional, Type
+
+from class_resolver import ClassResolver, Hint, OptionalKwargs
+from class_resolver.metaresolver import Metaresolver, is_hint
+
+
+class Baz:
+    def __init__(self, value: bool = False):
+        self.value = value
+
+
+class XBaz(Baz):
+    pass
+
+
+class YBaz(Baz):
+    pass
+
+
+baz_resolver = ClassResolver.from_subclasses(Baz)
+
+
+class Bar:
+    def __init__(
+        self,
+        baz: Hint[Baz] = None,
+        baz_kwargs: OptionalKwargs = None,
+    ):
+        self.baz = baz_resolver.make(baz, baz_kwargs)
+
+
+class AlphaBar(Bar):
+    pass
+
+
+class BetaBar(Bar):
+    pass
+
+
+bar_resolver = ClassResolver.from_subclasses(Bar)
+
+
+class Foo:
+    def __init__(
+        self,
+        *,
+        bar: Hint[Bar] = None,
+        bar_kwargs: OptionalKwargs = None,
+        param_1: float,
+        param_2: Optional[int] = None,
+    ):
+        self.bar = bar_resolver.make(bar, bar_kwargs)
+        self.param_1 = param_1
+        self.param_2 = param_2 or 5
+
+
+class AFoo(Foo):
+    pass
+
+
+class BFoo(Foo):
+    pass
+
+
+foo_resolver = ClassResolver.from_subclasses(Foo)
+
+
+class TestMetaResolver(unittest.TestCase):
+    """"""
+
+    def setUp(self) -> None:
+        self.meta_resolver = Metaresolver([baz_resolver, bar_resolver, foo_resolver])
+
+    def test_is_hint(self):
+        """Test hint predicate."""
+        self.assertTrue(is_hint(Hint[Foo], Foo))
+        self.assertFalse(is_hint(Hint[Foo], Bar))
+        self.assertFalse(is_hint(Type[Bar], Bar))
+        self.assertFalse(is_hint(str, Bar))
+        self.assertFalse(is_hint(None, Bar))
+
+    def test_check(self):
+        self.assertTrue(self.meta_resolver.check_kwargs(
+            Foo, AFoo,
+            {
+                "bar": "alpha",
+                "bar_kwargs": {
+                    "baz": "x",
+                    "baz_kwargs": {
+                        "value": True,
+                    }
+                },
+                "param_1": 3.0,
+                # Param 2 is optional, so not necessary to give
+            },
+        ))
+        self.assertTrue(self.meta_resolver.check_kwargs(
+            Foo, AFoo,
+            {
+                "bar": "alpha",
+                "bar_kwargs": {
+                    "baz": "x",
+                    # baz_kwargs value not necessary since has default
+                },
+                "param_1": 3.0,
+                # Param 2 is optional, so not necessary to give
+            },
+        ))
+        self.assertFalse(self.meta_resolver.check_kwargs(
+            Foo, AFoo,
+            {
+                "bar": "alpha",
+                "bar_kwargs": {
+                    "baz": "x",
+                },
+                # Missing param_1 !!
+            },
+        ))

--- a/tests/test_metaresolver.py
+++ b/tests/test_metaresolver.py
@@ -81,39 +81,48 @@ class TestMetaResolver(unittest.TestCase):
         self.assertFalse(is_hint(None, Bar))
 
     def test_check(self):
-        self.assertTrue(self.meta_resolver.check_kwargs(
-            Foo, AFoo,
-            {
-                "bar": "alpha",
-                "bar_kwargs": {
-                    "baz": "x",
-                    "baz_kwargs": {
-                        "value": True,
-                    }
+        self.assertTrue(
+            self.meta_resolver.check_kwargs(
+                Foo,
+                AFoo,
+                {
+                    "bar": "alpha",
+                    "bar_kwargs": {
+                        "baz": "x",
+                        "baz_kwargs": {
+                            "value": True,
+                        },
+                    },
+                    "param_1": 3.0,
+                    # Param 2 is optional, so not necessary to give
                 },
-                "param_1": 3.0,
-                # Param 2 is optional, so not necessary to give
-            },
-        ))
-        self.assertTrue(self.meta_resolver.check_kwargs(
-            Foo, AFoo,
-            {
-                "bar": "alpha",
-                "bar_kwargs": {
-                    "baz": "x",
-                    # baz_kwargs value not necessary since has default
+            )
+        )
+        self.assertTrue(
+            self.meta_resolver.check_kwargs(
+                Foo,
+                AFoo,
+                {
+                    "bar": "alpha",
+                    "bar_kwargs": {
+                        "baz": "x",
+                        # baz_kwargs value not necessary since has default
+                    },
+                    "param_1": 3.0,
+                    # Param 2 is optional, so not necessary to give
                 },
-                "param_1": 3.0,
-                # Param 2 is optional, so not necessary to give
-            },
-        ))
-        self.assertFalse(self.meta_resolver.check_kwargs(
-            Foo, AFoo,
-            {
-                "bar": "alpha",
-                "bar_kwargs": {
-                    "baz": "x",
+            )
+        )
+        self.assertFalse(
+            self.meta_resolver.check_kwargs(
+                Foo,
+                AFoo,
+                {
+                    "bar": "alpha",
+                    "bar_kwargs": {
+                        "baz": "x",
+                    },
+                    # Missing param_1 !!
                 },
-                # Missing param_1 !!
-            },
-        ))
+            )
+        )


### PR DESCRIPTION
This PR implements a pseudo-static type checker that takes a given dictionary to instantiate a given class and checks if it is correctly formatted. It raises an exception if it does not suffice.