### PR TITLE
Add subset functionality

### DIFF
--- a/src/class_resolver/base.py
+++ b/src/class_resolver/base.py
@@ -109,6 +109,19 @@ class BaseResolver(ABC, Generic[X, Y]):
         """Iterate over the registered elements."""
         return iter(self.lookup_dict.values())
 
+    def subresolver(self, keys: Iterable[str]) -> "BaseResolver[X, Y]":
+        """Create a resolver that's a subset of this one."""
+        elements = [
+            self.lookup_str(key)
+            for key in keys
+        ]
+        return self.__class__(
+            elements=elements,
+            default=self.default,
+            synonyms=self.synonyms,
+            suffix=self.suffix,
+        )
+
     @property
     def options(self) -> Set[str]:
         """Return the normalized option names."""
@@ -171,6 +184,17 @@ class BaseResolver(ABC, Generic[X, Y]):
     @abstractmethod
     def lookup(self, query: Hint[X], default: Optional[X] = None) -> X:
         """Lookup an element."""
+
+    def lookup_str(self, query: str) -> X:
+        """Lookup an element by name."""
+        key = self.normalize(query)
+        if key in self.lookup_dict:
+            return self.lookup_dict[key]
+        elif key in self.synonyms:
+            return self.synonyms[key]
+        else:
+            valid_choices = sorted(self.options)
+            raise KeyError(f"{query} is an invalid. Try one of: {valid_choices}")
 
     def docdata(self, query: Hint[X], *path: str, default: Optional[X] = None):
         """Lookup an element and get its docdata.

--- a/src/class_resolver/func.py
+++ b/src/class_resolver/func.py
@@ -29,14 +29,7 @@ class FunctionResolver(BaseResolver[X, X]):
         elif callable(query):
             return query  # type: ignore
         elif isinstance(query, str):
-            key = self.normalize(query)
-            if key in self.lookup_dict:
-                return self.lookup_dict[key]
-            elif key in self.synonyms:
-                return self.synonyms[key]
-            else:
-                valid_choices = sorted(self.options)
-                raise KeyError(f"{query} is an invalid. Try one of: {valid_choices}")
+            return self.lookup_str(query)
         else:
             raise TypeError(f"Invalid function: {type(query)} - {query}")
 


### PR DESCRIPTION
`BaseResolver.subresolver()` allows for the resolver to be subsetted based on a list of keys. This might be useful for HPO scenarios.