### PR TITLE
Add optuna categorical suggestion function

### DIFF
--- a/src/class_resolver/base.py
+++ b/src/class_resolver/base.py
@@ -4,11 +4,24 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Collection, Dict, Generic, Iterable, Iterator, Mapping, Optional, Set
+from typing import (
+    TYPE_CHECKING,
+    Collection,
+    Dict,
+    Generic,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Set,
+)
 
 from pkg_resources import iter_entry_points
 
 from .utils import Hint, OptionalKwargs, X, Y, make_callback, normalize_string
+
+if TYPE_CHECKING:
+    import optuna
 
 __all__ = [
     "BaseResolver",
@@ -261,3 +274,8 @@ class BaseResolver(ABC, Generic[X, Y]):
         """Make a resolver from the elements registered at the given entrypoint."""
         elements = cls._from_entrypoint(group)
         return cls(elements, **kwargs)
+
+    def optuna_lookup(self, trial: "optuna.Trial", name: str) -> X:
+        """Suggest an element from this resolver for hyper-parameter optimization in Optuna."""
+        key = trial.suggest_categorical(name, sorted(self.lookup_dict))
+        return self.lookup(key)

--- a/src/class_resolver/base.py
+++ b/src/class_resolver/base.py
@@ -298,7 +298,9 @@ class BaseResolver(ABC, Generic[X, Y]):
 
             def objective(trial: optuna.Trial) -> float:
                 x, y = datasets.load_iris(return_X_y=True)
-                x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.33, random_state=42)
+                x_train, x_test, y_train, y_test = train_test_split(
+                    x, y, test_size=0.33, random_state=42,
+                )
                 clf_cls = classifier_resolver.optuna_lookup(trial, "model")
                 clf = clf_cls()
                 clf.fit(x_train, y_train)

--- a/src/class_resolver/base.py
+++ b/src/class_resolver/base.py
@@ -280,8 +280,9 @@ class BaseResolver(ABC, Generic[X, Y]):
 
         :param trial: A trial object from :mod:`optuna`. Note that this object shouldn't be constructed
             by the developer, and should only get constructed inside the optuna framework when
-            using :meth:`optuna.Study.optimiz`.
+            using :meth:`optuna.Study.optimize`.
         :param name: The name of the `param` within an optuna study.
+        :returns: An element chosen by optuna, then run through :func:`lookup`.
 
         In the following example, Optuna is used to determine the best classification
         algorithm from scikit-learn when applied to the famous iris dataset.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -256,7 +256,7 @@ class TestResolver(unittest.TestCase):
     @unittest.skipIf(optuna is None, "optuna is not installed")
     @unittest.skipIf(sklearn is None, "sklearn is not installed")
     def test_optuna_suggest(self):
-        """Test suggesting categoric for optuna."""
+        """Test suggesting categorical for optuna."""
         import optuna
         from sklearn import datasets
         from sklearn.base import BaseEstimator
@@ -275,6 +275,7 @@ class TestResolver(unittest.TestCase):
         )
 
         def objective(trial: optuna.Trial) -> float:
+            """Calculate the classification accuracy for the iris dataset."""
             x, y = datasets.load_iris(return_X_y=True)
             x_train, x_test, y_train, y_test = train_test_split(
                 x, y, test_size=0.33, random_state=42


### PR DESCRIPTION
This PR adds a convenience function to the base resolver class for running HPO with Optuna. In the toy example below, it uses the scikit-learn classifier resolver in combination with Optuna to pick the best classification algorithm for the iris dataset.

```python

import optuna
from sklearn import datasets
from sklearn.model_selection import train_test_split

from class_resolver.contrib.sklearn import classifier_resolver


def objective(trial: optuna.Trial) -> float:
    x, y = datasets.load_iris(return_X_y=True)
    x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.33, random_state=42)
    clf_cls = classifier_resolver.optuna_lookup(trial, "model")
    clf = clf_cls()
    clf.fit(x_train, y_train)
    return clf.score(x_test, y_test)


study = optuna.create_study(direction="maximize")
study.optimize(objective, n_trials=100)
```