### PR TITLE
Include synonyms into click.option

### DIFF
--- a/src/class_resolver/base.py
+++ b/src/class_resolver/base.py
@@ -251,7 +251,7 @@ class BaseResolver(ABC, Generic[X, Y]):
         # TODO are there better ways to type options?
         return click.option(  # type:ignore
             *flags,
-            type=click.Choice(list(self.lookup_dict), case_sensitive=False),
+            type=click.Choice(list(self.options), case_sensitive=False),
             default=[key] if kwargs.get("multiple") else key,
             show_default=True,
             callback=None if as_string else make_callback(self.lookup),


### PR DESCRIPTION
This PR makes sure to include synonyms into the options available in CLI.